### PR TITLE
Dialer:Fix crash if device has no proximity sensor.

### DIFF
--- a/src/com/android/dialer/util/MultiSensorManager.java
+++ b/src/com/android/dialer/util/MultiSensorManager.java
@@ -138,7 +138,7 @@ public class MultiSensorManager {
         Sensor proximitySensor = sensorManager.getDefaultSensor(Sensor.TYPE_PROXIMITY);
         Sensor acceleroMeter = sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER);
         Sensor magneticSensor = sensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD);
-        if (proximitySensor == null && acceleroMeter == null && magneticSensor == null) {
+        if (proximitySensor == null || acceleroMeter == null || magneticSensor == null) {
             mMultiSensorListener = null;
         } else {
             mMultiSensorListener =


### PR DESCRIPTION
If device has no proximity sensor, application crashes with NullPointerException on init.
Fix this.

Change-Id: Ic6152c389a622f6430b9d757a543525447c87201
